### PR TITLE
Fixed error importing Illinois campaign contributions data

### DIFF
--- a/pgsql_big_dedupe_example/pgsql_big_dedupe_example_init_db.py
+++ b/pgsql_big_dedupe_example/pgsql_big_dedupe_example_init_db.py
@@ -34,8 +34,8 @@ if not os.path.exists(contributions_zip_file):
     print('downloading', contributions_zip_file, '(~60mb) ...')
     u = requests.get(
         'https://s3.amazonaws.com/dedupe-data/Illinois-campaign-contributions.txt.zip')
-    localFile = open(contributions_zip_file, 'w')
-    localFile.write(u.read())
+    localFile = open(contributions_zip_file, 'wb')
+    localFile.write(u.content)
     localFile.close()
 
 if not os.path.exists(contributions_txt_file):


### PR DESCRIPTION
in the response, a method read() was being called that didn't exist on the object.  The correct attribute is content.  It returns binary content, which is what we want for downloading a zip file.  We then at the flag 'b' to the file we open to let it know we will be writing binary data