### PR TITLE
Data cleanup that fixes #42

### DIFF
--- a/mysql_example/mysql_init_db.py
+++ b/mysql_example/mysql_init_db.py
@@ -103,6 +103,14 @@ c.execute("DELETE FROM raw_table WHERE LENGTH(date_recieved) < 10")
 # set empty, non-zero, strings in date columns to null
 c.execute("UPDATE raw_table SET report_period_begin = NULL WHERE LENGTH(report_period_begin) < 10")
 c.execute("UPDATE raw_table SET report_period_end = NULL WHERE LENGTH(report_period_end) < 10")
+
+#committee ID is requred. Remove the 2 rows that don't have it.
+c.execute("DELETE FROM raw_table WHERE committee_id=''");
+
+# There's a record with a date stuck in the committee_id column, which causes
+# problems when inserting into the contributions table below. Get rid of it this 
+# way.
+c.execute("DELETE FROM raw_table WHERE LENGTH( committee_id ) > 9")
 conn.commit()
 
 

--- a/mysql_example/mysql_init_db.py
+++ b/mysql_example/mysql_init_db.py
@@ -95,7 +95,13 @@ c.execute("LOAD DATA LOCAL INFILE %s INTO TABLE raw_table "
           " report_period_begin, report_period_end, "
           " committee_name, committee_id, @dummy)",
           (contributions_txt_file,))
+
+# Remove the very few records that mess up the demo 
+# (demo purposes only! Don't do something like this in production)
+c.execute("DELETE FROM raw_table WHERE LENGTH(date_recieved) < 10")
 conn.commit()
+
+
 
 print('creating donors table...')
 c.execute("CREATE TABLE donors "

--- a/mysql_example/mysql_init_db.py
+++ b/mysql_example/mysql_init_db.py
@@ -99,6 +99,10 @@ c.execute("LOAD DATA LOCAL INFILE %s INTO TABLE raw_table "
 # Remove the very few records that mess up the demo 
 # (demo purposes only! Don't do something like this in production)
 c.execute("DELETE FROM raw_table WHERE LENGTH(date_recieved) < 10")
+
+# set empty, non-zero, strings in date columns to null
+c.execute("UPDATE raw_table SET report_period_begin = NULL WHERE LENGTH(report_period_begin) < 10")
+c.execute("UPDATE raw_table SET report_period_end = NULL WHERE LENGTH(report_period_end) < 10")
 conn.commit()
 
 


### PR DESCRIPTION
Adds a few extra SQL statements to clean up the data in the `raw_table` data before trying to insert it into `contributions`. Fixes #42 so that mysql_init_db.py runs properly when dealing with MySQL 5.7