### PR TITLE
Fix typo in record linkage example

### DIFF
--- a/record_linkage_example/record_linkage_example.py
+++ b/record_linkage_example/record_linkage_example.py
@@ -149,7 +149,7 @@ if __name__ == '__main__':
         # exists, we will skip all the training and learning next time we run
         # this file.
         with open(settings_file, 'wb') as sf:
-            linker.writeSettings(sf)
+            linker.write_settings(sf)
 
     # ## Blocking
 


### PR DESCRIPTION
The correct method name is `write_settings`.