### PR TITLE
Safer records

### DIFF
--- a/mysql_example/mysql_example.py
+++ b/mysql_example/mysql_example.py
@@ -34,10 +34,16 @@ import dedupe.backport
 
 
 def record_pairs(result_set):
+    def safe(d):
+        return {
+            k: None if v is None or (type(v) == str and len(v) == 0) else v
+            for (k, v) in d.items()
+        }
+
     for i, row in enumerate(result_set):
         a_record_id, a_record, b_record_id, b_record = row
-        record_a = (a_record_id, json.loads(a_record))
-        record_b = (b_record_id, json.loads(b_record))
+        record_a = (a_record_id, safe(json.loads(a_record)))
+        record_b = (b_record_id, safe(json.loads(b_record)))
 
         yield record_a, record_b
 


### PR DESCRIPTION
This example easily generates empty strings when changed to use new data, while dedupe expects None, leading to errors (https://github.com/dedupeio/dedupe/issues/639 and https://github.com/dedupeio/affinegap/issues/4).
This is a simple patch that cleans the records, converting empty strings to None. Perhaps this could be used on CSV and other examples as well.