### PR TITLE
Resolving cluster_id issue in gazetteer_example.py

### DIFF
--- a/gazetteer_example/gazetteer_example.py
+++ b/gazetteer_example/gazetteer_example.py
@@ -163,8 +163,12 @@ if __name__ == '__main__':
         for canon_id, score in matches:
             cluster_membership[messy_id] = {'Cluster ID': cluster_id,
                                             'Link Score': score}
-            cluster_membership[canon_id] = {'Cluster ID': cluster_id,
-                                            'Link Score': score}
+            try:
+              cluster_membership[canon_id] += [{'Cluster ID': cluster_id,
+                                            'Link Score': score}]
+            except:
+              cluster_membership[canon_id] = [{'Cluster ID': cluster_id,
+                                            'Link Score': score}]
 
     with open(output_file, 'w') as f:
 
@@ -188,7 +192,12 @@ if __name__ == '__main__':
 
                     record_id = filename + str(row_id)
                     cluster_details = cluster_membership.get(record_id, {})
-                    row['source file'] = fileno
-                    row.update(cluster_details)
-
-                    writer.writerow(row)
+                    if type(cluster_details)==dict:
+                        row['source file'] = fileno
+                        row.update(cluster_details)
+                        writer.writerow(row)
+                    else:
+                        for i in cluster_details:
+                            row['source file'] = fileno
+                            row.update(i)
+                            writer.writerow(row)

--- a/gazetteer_example/gazetteer_example.py
+++ b/gazetteer_example/gazetteer_example.py
@@ -158,7 +158,6 @@ if __name__ == '__main__':
     results = gazetteer.search(messy, n_matches=2, generator=True)
 
     cluster_membership = {}
-    cluster_id = 0
 
     for cluster_id, (messy_id, matches) in enumerate(results):
         for canon_id, score in matches:
@@ -166,7 +165,6 @@ if __name__ == '__main__':
                                             'Link Score': score}
             cluster_membership[canon_id] = {'Cluster ID': cluster_id,
                                             'Link Score': score}
-            cluster_id += 1
 
     with open(output_file, 'w') as f:
 


### PR DESCRIPTION
Currently gazetteer_example.py has an issue with the cluster_id assignment. (see #134  )

This pull resolves that issue by assigning a unique cluster_id to each entry in the messy dataset, and then assigning that same cluster_id to all the matches from the canonical dataset. It allows entries in the canonical dataset to have multiple cluster_ids, and then outputs a csv that can be sorted by cluster_id to see each entry in messy dataset and all its corresponding matches from the canonical dataset.